### PR TITLE
Fix PID conversion code

### DIFF
--- a/Libraries/Canbus/Canbus.cpp
+++ b/Libraries/Canbus/Canbus.cpp
@@ -129,39 +129,39 @@ char CanbusClass::ecu_req(unsigned char pid,  char *buffer)
 							if((message.id == PID_REPLY) && (message.data[2] == pid))	// Check message is the reply and its the right PID
 							{	
 								/* Details from http://en.wikipedia.org/wiki/OBD-II_PIDs */
-								if(message.data[2] = ENGINE_RPM)
+								if(message.data[2] == ENGINE_RPM)
 								{   
 									//ENGINE_RPM:  			 ((A*256)+B)/4    [RPM]
 									engine_data =  ((message.data[3]*256) + message.data[4])/4;
 								}
 								
-								if(message.data[2] = ENGINE_COOLANT_TEMP)
+								if(message.data[2] == ENGINE_COOLANT_TEMP)
 								{
 									//ENGINE_COOLANT_TEMP: 	A-40			  [degree C]
 									engine_data =  message.data[3] - 40;
 								}
 							
-								if(message.data[2] = VEHICLE_SPEED)
+								if(message.data[2] == VEHICLE_SPEED)
 								{
 									//VEHICLE_SPEED: 		 A				  [km]
 									engine_data =  message.data[3];
 								}
 
-								if(message.data[2] = MAF_SENSOR)
+								if(message.data[2] == MAF_SENSOR)
 								{
 									//MAF_SENSOR:   			((256*A)+B) / 100  [g/s]
 									engine_data =  ((message.data[3]*256) + message.data[4])/100;
 									sprintf(buffer,"%d g/s",(int) engine_data);
 								}
 
-								if(message.data[2] = O2_VOLTAGE)
+								if(message.data[2] == O2_VOLTAGE)
 								{
 									//O2_VOLTAGE:    		A * 0.005   (B-128) * 100/128 (if B==0xFF, sensor is not used in trim calc)
 									engine_data = message.data[3]*0.005;
 									sprintf(buffer,"%d V",(int) engine_data);
 								}
 								
-								 if(message.data[2] = THROTTLE)
+								 if(message.data[2] == THROTTLE)
 								{
 									//THROTTLE:				// Throttle Position
 									engine_data = (message.data[3]*100)/255;


### PR DESCRIPTION
This fixes a C coding error in the code to convert PID replies to physical values that caused all the formulas to be used in succession.
