### PR TITLE
Fix failure to init mpc2515

### DIFF
--- a/Libraries/Canbus/mcp2515.c
+++ b/Libraries/Canbus/mcp2515.c
@@ -146,7 +146,7 @@ uint8_t mcp2515_init(uint8_t speed)
 	SET(MCP2515_CS);
 	
 	// wait a little bit until the MCP2515 has restarted
-	_delay_us(10);
+	_delay_us(50);
 	
 	// load CNF1..3 Register
 	RESET(MCP2515_CS);


### PR DESCRIPTION
Delay in mpc2515_init() in mpc2515.c increased to 50us to fix init failure error on some setups.

This fix was reported by [Wesley thomas](https://arduino.stackexchange.com/users/28683/wesley-thomas) via arduino.stackexchange [answer](https://arduino.stackexchange.com/a/31769).